### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/hosts/blade/configuration.nix
+++ b/hosts/blade/configuration.nix
@@ -42,7 +42,7 @@
   # Enable flake support
   nix.settings.experimental-features = ["nix-command" "flakes"];
 
-  # Enable printing with auto-discovery (see https://nixos.wiki/wiki/Printing)
+  # Enable printing with auto-discovery (see https://wiki.nixos.org/wiki/Printing)
   services.printing = {
     enable = true;
     drivers = [pkgs.hplip]; # For HP printers only (magically works)

--- a/hosts/nzxt/configuration.nix
+++ b/hosts/nzxt/configuration.nix
@@ -41,7 +41,7 @@
   # Enable flake support
   nix.settings.experimental-features = ["nix-command" "flakes"];
 
-  # Enable printing with auto-discovery (see https://nixos.wiki/wiki/Printing)
+  # Enable printing with auto-discovery (see https://wiki.nixos.org/wiki/Printing)
   services.printing = {
     enable = true;
     drivers = [pkgs.hplip]; # For HP printers only (magically works)

--- a/modules/hardware/blade.nix
+++ b/modules/hardware/blade.nix
@@ -10,10 +10,10 @@
   };
 
   config = lib.mkIf config.razer-blade.enable {
-    # See https://nixos.wiki/wiki/Hardware/Razer for some more information.
+    # See https://wiki.nixos.org/wiki/Hardware/Razer for some more information.
 
     # Enabled NVIDIA drivers
-    # See https://nixos.wiki/wiki/Nvidia for more information.
+    # See https://wiki.nixos.org/wiki/Nvidia for more information.
     hardware.opengl.enable = true;
     services.xserver.videoDrivers = ["nvidia"];
     hardware.nvidia = {


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️